### PR TITLE
klte{,chn}duo*: Regen makefiles

### DIFF
--- a/kltechnduo/kltechnduo-vendor.mk
+++ b/kltechnduo/kltechnduo-vendor.mk
@@ -37,7 +37,6 @@ PRODUCT_COPY_FILES += \
     vendor/samsung/kltechnduo/proprietary/vendor/lib/libcneapiclient.so:system/vendor/lib/libcneapiclient.so \
     vendor/samsung/kltechnduo/proprietary/vendor/lib/libcneconn.so:system/vendor/lib/libcneconn.so \
     vendor/samsung/kltechnduo/proprietary/vendor/lib/libcneqmiutils.so:system/vendor/lib/libcneqmiutils.so \
-    vendor/samsung/kltechnduo/proprietary/vendor/lib/libconfigdb.so:system/vendor/lib/libconfigdb.so \
     vendor/samsung/kltechnduo/proprietary/vendor/lib/liblisten.so:system/vendor/lib/liblisten.so \
     vendor/samsung/kltechnduo/proprietary/vendor/lib/liblistenhardware.so:system/vendor/lib/liblistenhardware.so \
     vendor/samsung/kltechnduo/proprietary/vendor/lib/liblistenjni.so:system/vendor/lib/liblistenjni.so \

--- a/klteduos/klteduos-vendor.mk
+++ b/klteduos/klteduos-vendor.mk
@@ -35,7 +35,6 @@ PRODUCT_COPY_FILES += \
     vendor/samsung/klteduos/proprietary/vendor/lib/libcneapiclient.so:system/vendor/lib/libcneapiclient.so \
     vendor/samsung/klteduos/proprietary/vendor/lib/libcneconn.so:system/vendor/lib/libcneconn.so \
     vendor/samsung/klteduos/proprietary/vendor/lib/libcneqmiutils.so:system/vendor/lib/libcneqmiutils.so \
-    vendor/samsung/klteduos/proprietary/vendor/lib/libconfigdb.so:system/vendor/lib/libconfigdb.so \
     vendor/samsung/klteduos/proprietary/vendor/lib/liblisten.so:system/vendor/lib/liblisten.so \
     vendor/samsung/klteduos/proprietary/vendor/lib/liblistenhardware.so:system/vendor/lib/liblistenhardware.so \
     vendor/samsung/klteduos/proprietary/vendor/lib/liblistenjni.so:system/vendor/lib/liblistenjni.so \


### PR DESCRIPTION
* We properly moved libconfigdb.so, but the entry in proprietary-files
  was hiding in the wrong place for the two duos devices. Sad!

Change-Id: I7cfe1a88bdba95bcfd798dde7694aadfa27f3e4b